### PR TITLE
明日やる、今度やるの枠表示

### DIFF
--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -1,12 +1,18 @@
-import type { VFC } from "react";
+// import { Footer } from "src/layout/Footer";
+import clsx from "clsx";
+import { memo } from "react";
 import { useEffect, useState } from "react";
 
 import { useStore } from "../libs/store";
 import type { TodosState } from "../types";
 import { TodoTody } from "./TodoToday";
-// import { Footer } from "src/layout/Footer";
 
-export const ListTodoToday: VFC<TodosState> = () => {
+type Props = {
+  title: string;
+  target: "1" | "2" | "3";
+};
+
+export const ListTodoToday = memo<Props>((props) => {
   const todos = useStore((state: TodosState) => {
     return state.todos;
   });
@@ -51,8 +57,16 @@ export const ListTodoToday: VFC<TodosState> = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   return (
-    <>
-      <div className="mb-3 text-2xl font-semibold text-primary">今日する</div>
+    <div className="w-full lg:w-1/3">
+      <div
+        className={clsx("mb-3 text-2xl font-semibold", {
+          "text-primary": props.target == "1",
+          "text-yellow-500": props.target == "2",
+          "text-yellow-300": props.target == "3",
+        })}
+      >
+        {props.title}
+      </div>
       <div className="flex flex-col">
         <div className="flex items-center">
           <button
@@ -63,12 +77,16 @@ export const ListTodoToday: VFC<TodosState> = () => {
           </button>
           <div className="text-gray-300">タスクを追加する</div>
         </div>
-        <div className="overflow-y-scroll my-5 max-h-72">
+        <div className="overflow-y-scroll my-5 w-full max-h-72">
           <ul>{/* ここにmockのデータを取得したい */}</ul>
           <ol>
             {todos.map((todo) => {
               return (
-                <TodoTody todo={todo} key={`todo-${todo.text}-${todo.id}`} />
+                <TodoTody
+                  todo={todo}
+                  key={`todo-${todo.text}-${todo.id}`}
+                  target={props.target}
+                />
               );
             })}
           </ol>
@@ -107,6 +125,8 @@ export const ListTodoToday: VFC<TodosState> = () => {
           </div>
         </>
       </div>
-    </>
+    </div>
   );
-};
+});
+
+ListTodoToday.displayName = "ListTodoToday";

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -61,8 +61,8 @@ export const ListTodoToday = memo<Props>((props) => {
       <div
         className={clsx("mb-3 text-2xl font-semibold", {
           "text-primary": props.target == "1",
-          "text-yellow-500": props.target == "2",
-          "text-yellow-300": props.target == "3",
+          "text-secondary": props.target == "2",
+          "text-tertiary": props.target == "3",
         })}
       >
         {props.title}

--- a/src/components/TodoToday.tsx
+++ b/src/components/TodoToday.tsx
@@ -23,8 +23,8 @@ export const TodoTody = memo<Props>((props) => {
           "mr-4 w-6 h-6 rounded-full ring-0 focus:ring-gray-400",
           {
             "text-primary": props.target == "1",
-            "text-yellow-500": props.target == "2",
-            "text-yellow-300": props.target == "3",
+            "text-secondary": props.target == "2",
+            "text-tertiary": props.target == "3",
           }
         )}
         type="checkbox"

--- a/src/components/TodoToday.tsx
+++ b/src/components/TodoToday.tsx
@@ -1,13 +1,15 @@
-import type { VFC } from "react";
+import clsx from "clsx";
+import { memo } from "react";
 
 import { useStore } from "../libs/store";
 import type { ListTodo, TodosState } from "../types";
 
 type Props = {
   todo: ListTodo;
+  target: "1" | "2" | "3";
 };
 
-export const TodoTody: VFC<Props> = (props) => {
+export const TodoTody = memo<Props>((props) => {
   const toggleComplete = useStore((state: TodosState) => {
     return state.toggleDone;
   });
@@ -17,7 +19,14 @@ export const TodoTody: VFC<Props> = (props) => {
   return (
     <div className="flex items-center mb-4">
       <input
-        className="mr-4 w-6 h-6 text-primary rounded-full ring-0 focus:ring-gray-400"
+        className={clsx(
+          "mr-4 w-6 h-6 rounded-full ring-0 focus:ring-gray-400",
+          {
+            "text-primary": props.target == "1",
+            "text-yellow-500": props.target == "2",
+            "text-yellow-300": props.target == "3",
+          }
+        )}
         type="checkbox"
         checked={props.todo.done}
         // eslint-disable-next-line react/jsx-handler-names
@@ -39,4 +48,6 @@ export const TodoTody: VFC<Props> = (props) => {
       </button>
     </div>
   );
-};
+});
+
+TodoTody.displayName = "TodoTody";

--- a/src/pages/auth/Sign.tsx
+++ b/src/pages/auth/Sign.tsx
@@ -31,7 +31,7 @@ export const Sign: VFC<SignProps> = (props) => {
     <div className="grid place-items-center w-screen h-screen bg-gray-200 dark:bg-gray-700">
       <div className="p-4">
         <div className="flex justify-center">
-          <QinTodoIcon className="w-48" />
+          <QinTodoIcon />
         </div>
         <div className="mt-20 space-y-5">
           <Button

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -7,21 +7,11 @@ const Home = () => {
   return (
     <Layout>
       <ThemeChanger />
-      <ListTodoToday
-        todos={[]}
-        getTempTodos={function (): void {
-          throw new Error("Function not implemented.");
-        }}
-        addTodo={function (_text: string): void {
-          throw new Error("Function not implemented.");
-        }}
-        removeTodo={function (_index: string): void {
-          throw new Error("Function not implemented.");
-        }}
-        toggleDone={function (_index: string): void {
-          throw new Error("Function not implemented.");
-        }}
-      />
+      <div className="flex flex-col lg:flex-row">
+        <ListTodoToday title="今日する" target="1" />
+        <ListTodoToday title="明日する" target="2" />
+        <ListTodoToday title="今度する" target="3" />
+      </div>
     </Layout>
   );
 };


### PR DESCRIPTION
明日やる、今度やるの枠だけ追加しました。
コンポーネント名に`today`とあるのは、別ISSUEにしましょう。

PC用とモバイル用で、横並び・縦並びも対応しましたが、動きはもう少し全体ができてから、リファクタリングしましょう。