### PR TITLE
並び替え時の更新処理追加

### DIFF
--- a/src/libs/dateFunc.ts
+++ b/src/libs/dateFunc.ts
@@ -18,7 +18,7 @@ export const getStringFromDate = (date: Date) => {
   const year_str: string = date.getFullYear().toString();
   //月だけ+1すること
   const month_str: string = (date.getMonth() + 1).toString().padStart(2, "0");
-  const day_str: string = date.getDate().toString();
+  const day_str: string = date.getDate().toString().padStart(2, "0");
 
   let format_str = "YYYY-MM-DD";
   format_str = format_str.replace(/YYYY/g, year_str);

--- a/src/libs/store.ts
+++ b/src/libs/store.ts
@@ -311,7 +311,7 @@ const useStore = create<TodosState>(
           return { activeTarget: activeTarget, orveTarget: orveTarget };
         });
       },
-      taskDropOver: (id, overId, strDate) => {
+      taskDropOver: (id, overId, strDate, authUser) => {
         return set((state) => {
           const putTodos: ListTodo[] = state.todos;
           // 移動先が無い場合は、何もせずに終了する
@@ -376,17 +376,29 @@ const useStore = create<TodosState>(
             index < activeContainer.length;
             index += 1
           ) {
+            const sortKeyBak = activeContainer[index].sortKey;
             activeContainer[index].sortKey = activeIndex + 1;
+            // putリクエスト発行
+            if (sortKeyBak !== activeContainer[index].sortKey) {
+              state.updateTodo(activeContainer[index], authUser);
+            }
             activeIndex += 1;
           }
 
           // 移動先コンテナに、移動対象を追加する
           const overContainer = overItems.slice(0, newIndex);
           overContainer.push(newItem);
+          // putリクエスト発行
+          state.updateTodo(newItem, authUser);
 
           const overContainerBk = overItems.slice(newIndex, overItems.length);
           for (let index = 0; index < overContainerBk.length; index += 1) {
+            const sortKeyBak = overContainerBk[index].sortKey;
             overContainerBk[index].sortKey = overIndex + 1;
+            // putリクエスト発行
+            if (sortKeyBak !== overContainerBk[index].sortKey) {
+              state.updateTodo(overContainerBk[index], authUser);
+            }
             overContainer.push(overContainerBk[index]);
             overIndex += 1;
           }
@@ -410,7 +422,7 @@ const useStore = create<TodosState>(
           return { todos: putTodos, activeId: null };
         });
       },
-      taskDropEnd: (id, overId, strDate) => {
+      taskDropEnd: (id, overId, strDate, authUser) => {
         return set((state) => {
           const putTodos: ListTodo[] = state.todos;
 
@@ -446,7 +458,12 @@ const useStore = create<TodosState>(
               index < activeContainer.length;
               index += 1
             ) {
+              const sortKeyBak = activeContainer[index].sortKey;
               activeContainer[index].sortKey = sortIndex + 1;
+              // putリクエスト発行
+              if (sortKeyBak !== activeContainer[index].sortKey) {
+                state.updateTodo(activeContainer[index], authUser);
+              }
               sortIndex += 1;
             }
           } else {

--- a/src/libs/store.ts
+++ b/src/libs/store.ts
@@ -190,7 +190,7 @@ const useStore = create<TodosState>(
           };
         });
       },
-      removeTodo: async (id: string, authUser) => {
+      removeTodo: async (id, authUser) => {
         const idToken = await authUser.getIdToken();
         await axios
           .delete(`${apiUrl}/${id}`, {
@@ -213,12 +213,12 @@ const useStore = create<TodosState>(
           };
         });
       },
-      setIsAddInput: (isAddInput: boolean) => {
+      setIsAddInput: (isAddInput) => {
         return set(() => {
           return { isAddInput: isAddInput };
         });
       },
-      toggleDone: async (editTodo: ListTodo, authUser) => {
+      toggleDone: async (editTodo, authUser) => {
         const idToken = await authUser.getIdToken();
         editTodo.isDone = !editTodo.isDone;
         if (editTodo.isDone) {
@@ -262,14 +262,14 @@ const useStore = create<TodosState>(
           };
         });
       },
-      setEditTodo: (editTodo: ListTodo) => {
+      setEditTodo: (editTodo) => {
         return set(() => {
           return {
             editTodo: editTodo,
           };
         });
       },
-      setActiveId: (id: string) => {
+      setActiveId: (id) => {
         return set((state) => {
           const todo = state.todos.find((todo) => {
             todo.id === id;
@@ -283,7 +283,7 @@ const useStore = create<TodosState>(
           return { activeId: target };
         });
       },
-      findTarget: (id: string, isActive: boolean) => {
+      findTarget: (id, isActive) => {
         return set((state) => {
           const todo = state.todos.find((todo) => {
             return todo.id === id;
@@ -311,12 +311,12 @@ const useStore = create<TodosState>(
           return { activeTarget: activeTarget, orveTarget: orveTarget };
         });
       },
-      taskDropOver: (id: string, overId: string, strDate: string) => {
+      taskDropOver: (id, overId, strDate) => {
         return set((state) => {
-          const updateTodos: ListTodo[] = state.todos;
+          const putTodos: ListTodo[] = state.todos;
           // 移動先が無い場合は、何もせずに終了する
           if (!overId || overId === "void") {
-            return { todos: updateTodos, activeId: null };
+            return { todos: putTodos, activeId: null };
           }
           // 移動元、移動先のコンテナが変わっていない場合は、何もせずに終了する
           if (
@@ -324,7 +324,7 @@ const useStore = create<TodosState>(
             !state.orveTarget ||
             state.activeTarget === state.orveTarget
           ) {
-            return { todos: updateTodos, activeId: null };
+            return { todos: putTodos, activeId: null };
           }
 
           const activeTarget: Target = state.activeTarget;
@@ -351,7 +351,7 @@ const useStore = create<TodosState>(
             return item.id === id;
           });
           if (!newItem) {
-            return { todos: updateTodos, activeId: null };
+            return { todos: putTodos, activeId: null };
           }
           switch (orveTarget) {
             case "today":
@@ -392,30 +392,30 @@ const useStore = create<TodosState>(
           }
           // 移動元の並びを全体のstateに反映する
           activeContainer.map((todo) => {
-            updateTodos.find((upTodo) => {
-              return upTodo.id === todo.id;
+            putTodos.find((putTodo) => {
+              return putTodo.id === todo.id;
             })
               ? todo
-              : updateTodos;
+              : putTodos;
           });
           // 移動先の並びを全体のstateに反映する
           overContainer.map((todo) => {
-            updateTodos.find((upTodo) => {
-              return upTodo.id === todo.id;
+            putTodos.find((putTodo) => {
+              return putTodo.id === todo.id;
             })
               ? todo
-              : updateTodos;
+              : putTodos;
           });
 
-          return { todos: updateTodos, activeId: null };
+          return { todos: putTodos, activeId: null };
         });
       },
-      taskDropEnd: (id: string, overId: string, strDate: string) => {
+      taskDropEnd: (id, overId, strDate) => {
         return set((state) => {
-          const updateTodos: ListTodo[] = state.todos;
+          const putTodos: ListTodo[] = state.todos;
 
           if (!state.activeTarget) {
-            return { todos: updateTodos, activeId: null };
+            return { todos: putTodos, activeId: null };
           }
 
           const activeTarget: Target = state.activeTarget;
@@ -454,14 +454,14 @@ const useStore = create<TodosState>(
           }
           // 移動後の並びを全体のstateに反映する
           activeContainer.map((todo) => {
-            updateTodos.find((upTodo) => {
-              return upTodo.id === todo.id;
+            putTodos.find((putTodo) => {
+              return putTodo.id === todo.id;
             })
               ? todo
-              : updateTodos;
+              : putTodos;
           });
 
-          return { todos: updateTodos, activeId: null };
+          return { todos: putTodos, activeId: null };
         });
       },
     };

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import type { NextPage } from "next";
-import { AuthAction, withAuthUser } from "next-firebase-auth";
+import { AuthAction, useAuthUser, withAuthUser } from "next-firebase-auth";
 import type { DOMAttributes } from "react";
 import { useEffect } from "react";
 import { ListTodo } from "src/components/ListTodo";
@@ -57,6 +57,7 @@ const Home: NextPage = () => {
     return state.setIsAddInput;
   });
   const strDate = getToday();
+  const authUser = useAuthUser();
 
   const todayTodosLen = selectTodos(allTodos, strDate, "today").length;
   const nextdayTodosLen = selectTodos(allTodos, strDate, "nextday").length;
@@ -94,7 +95,7 @@ const Home: NextPage = () => {
     findTarget(id, true);
     findTarget(overId, false);
 
-    taskDropOver(id, overId, strDate);
+    taskDropOver(id, overId, strDate, authUser);
   };
 
   //要素を離したとき
@@ -110,7 +111,7 @@ const Home: NextPage = () => {
       return;
     }
 
-    taskDropEnd(id, overId, strDate);
+    taskDropEnd(id, overId, strDate, authUser);
   };
 
   useEffect(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,8 +37,18 @@ export type TodosState = {
   setEditTodo: (editTodo: ListTodo) => void;
   setActiveId: (id: string) => void;
   findTarget: (id: string, isActive: boolean) => void;
-  taskDropOver: (id: string, overId: string, strDate: string) => void;
-  taskDropEnd: (id: string, overId: string, strDate: string) => void;
+  taskDropOver: (
+    id: string,
+    overId: string,
+    strDate: string,
+    authUser: AuthUserContext
+  ) => void;
+  taskDropEnd: (
+    id: string,
+    overId: string,
+    strDate: string,
+    authUser: AuthUserContext
+  ) => void;
 };
 
 export type Target = "today" | "nextday" | "otherday";


### PR DESCRIPTION
並び替え時の更新処理の対応を行いました。
ただ、バックエンドと接続すると「今日する」⇒「明日する」への移動ができなくなります。（３つのコンテナ間の移動ができなくなるという意味で、「今日する」⇒「明日する」は一例です。）
こちらは、別ISSUEにしようかと思います。

store.tsの中でいくつか型の定義をしていましたが、types/index.tsで定義していれば不要なため、削除しました。
また、`updateTodos`という変数を使っていましたが、`updateTodo`という関数があり、紛らわしいため変数名を変更しました。

